### PR TITLE
feat(gateways): add 5 free MCP servers for AI dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented here.
 
+## [1.5.0] - 2026-02-14
+
+### Added
+
+- **MCP servers for AI development** – 5 new free MCP servers added to the gateway for enhanced AI-assisted development workflows:
+  - **memory** (port 8027) – Anthropic reference server (`@modelcontextprotocol/server-memory`). Persistent knowledge graph that stores and retrieves context across sessions. No API key required.
+  - **git-mcp** (port 8028) – Anthropic reference server (`@modelcontextprotocol/server-git`). Local git operations (commit, branch, diff, log) complementing the GitHub gateway. No API key required.
+  - **fetch** (port 8029) – Anthropic reference server (`@modelcontextprotocol/server-fetch`). Web content fetching and markdown conversion for LLM consumption. No API key required.
+  - **Context7** (remote) – Up-to-date library/framework documentation lookup (`https://mcp.context7.com/mcp`). Free tier works without API key; configure key in Admin UI Passthrough Headers for higher rate limits. Uncommented in `gateways.txt`.
+  - **DeepWiki** (remote) – AI-powered codebase documentation for any public GitHub repo (`https://mcp.deepwiki.com/mcp`). Free, no authentication required.
+- **cursor-default expanded** – `virtual-servers.txt` cursor-default now includes memory, git-mcp, and fetch gateways alongside existing ones.
+- **Port overrides** – `.env` optional vars: `MEMORY_PORT`, `GIT_MCP_PORT`, `FETCH_PORT`.
+
 ## [1.4.3] - 2026-02-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The default `./start.sh` starts the gateway and these local translate services (
 | filesystem          | http://filesystem:8021/sse          | Set `FILESYSTEM_VOLUME` (host path) in .env; default `./workspace` |
 | reactbits           | http://reactbits:8022/sse           | reactbits-dev-mcp-server                                           |
 | snyk                | http://snyk:8023/sse                | Set `SNYK_TOKEN` in .env (Snyk CLI auth)                           |
+| memory              | http://memory:8027/sse              | Persistent knowledge graph (no API key)                            |
+| git-mcp             | http://git-mcp:8028/sse             | Local git operations: commit, branch, diff, log (no API key)      |
+| fetch               | http://fetch:8029/sse               | Web content fetching to markdown for LLM use (no API key)          |
 | tool-router         | http://tool-router:8030/sse         | Single entry point; set `GATEWAY_JWT` in .env (see cursor-router)  |
 | sqlite              | http://sqlite:8024/sse              | Set `SQLITE_DB_PATH` / `SQLITE_VOLUME` in .env; default `./data`   |
 | github              | http://github:8025/sse              | Set `GITHUB_PERSONAL_ACCESS_TOKEN` in .env                         |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,33 @@ services:
     ports:
       - "${GITHUB_PORT:-8025}:8025"
 
+  memory:
+    <<: *translate
+    command:
+      - sh
+      - -c
+      - 'python3 -m mcpgateway.translate --stdio "npx -y @modelcontextprotocol/server-memory" --expose-sse --port 8027 --host 0.0.0.0'
+    ports:
+      - "${MEMORY_PORT:-8027}:8027"
+
+  git-mcp:
+    <<: *translate
+    command:
+      - sh
+      - -c
+      - 'python3 -m mcpgateway.translate --stdio "npx -y @modelcontextprotocol/server-git" --expose-sse --port 8028 --host 0.0.0.0'
+    ports:
+      - "${GIT_MCP_PORT:-8028}:8028"
+
+  fetch:
+    <<: *translate
+    command:
+      - sh
+      - -c
+      - 'python3 -m mcpgateway.translate --stdio "npx -y @modelcontextprotocol/server-fetch" --expose-sse --port 8029 --host 0.0.0.0'
+    ports:
+      - "${FETCH_PORT:-8029}:8029"
+
   tool-router:
     build:
       context: .

--- a/scripts/gateways.txt
+++ b/scripts/gateways.txt
@@ -12,13 +12,17 @@ tavily|http://tavily:8020/sse|SSE
 filesystem|http://filesystem:8021/sse|SSE
 reactbits|http://reactbits:8022/sse|SSE
 snyk|http://snyk:8023/sse|SSE
+memory|http://memory:8027/sse|SSE
+git-mcp|http://git-mcp:8028/sse|SSE
+fetch|http://fetch:8029/sse|SSE
 tool-router|http://tool-router:8030/sse|SSE
 # sqlite/github often fail with "Unable to connect" or "Unexpected error"; uncomment after checking docker compose logs sqlite|github, or add via Admin UI.
 # sqlite|http://sqlite:8024/sse|SSE
 # github|http://github:8025/sse|SSE
 
 # Remote (stack): uncomment to register via script, or add to EXTRA_GATEWAYS in .env. Context7 needs API key in Admin UI (Passthrough Headers).
-# Context7|https://mcp.context7.com/mcp|STREAMABLEHTTP
+Context7|https://mcp.context7.com/mcp|STREAMABLEHTTP
+DeepWiki|https://mcp.deepwiki.com/mcp|STREAMABLEHTTP
 # Often unreachable or 406 from gateway; add via Admin UI if needed.
 # context-awesome|https://www.context-awesome.com/api/mcp|STREAMABLEHTTP
 # prisma-remote|https://mcp.prisma.io/mcp|STREAMABLEHTTP

--- a/scripts/virtual-servers.txt
+++ b/scripts/virtual-servers.txt
@@ -5,7 +5,7 @@
 # Connect Cursor to one server URL (e.g. .../servers/<UUID>/mcp) from the script output.
 #
 # cursor-default: core dev + search + browser (under 60 tools)
-cursor-default|sequential-thinking,filesystem,tavily,playwright,desktop-commander,chrome-devtools
+cursor-default|sequential-thinking,filesystem,tavily,playwright,desktop-commander,chrome-devtools,memory,git-mcp,fetch
 # cursor-search: search and docs only
 cursor-search|tavily
 # cursor-browser: browser automation


### PR DESCRIPTION
## Summary

Add 5 free, popular MCP servers to the gateway for enhanced AI-assisted development workflows.

### New Local Translate Services (docker-compose)

| Server | Port | Package | Description |
|--------|------|---------|-------------|
| **memory** | 8027 | `@modelcontextprotocol/server-memory` | Persistent knowledge graph — stores/retrieves context across sessions |
| **git-mcp** | 8028 | `@modelcontextprotocol/server-git` | Local git operations (commit, branch, diff, log) |
| **fetch** | 8029 | `@modelcontextprotocol/server-fetch` | Web content fetching + markdown conversion for LLM consumption |

### New Remote Servers (gateways.txt)

| Server | URL | Description |
|--------|-----|-------------|
| **Context7** | `https://mcp.context7.com/mcp` | Up-to-date library/framework docs (uncommented existing entry) |
| **DeepWiki** | `https://mcp.deepwiki.com/mcp` | AI-powered codebase documentation for public GitHub repos |

All 5 servers are **free with no API keys required** for core functionality. All three local servers are Anthropic reference implementations.

### Files Changed

- **`docker-compose.yml`** — 3 new translate services (memory, git-mcp, fetch)
- **`scripts/gateways.txt`** — 3 local entries + uncomment Context7 + add DeepWiki
- **`scripts/virtual-servers.txt`** — cursor-default expanded with memory, git-mcp, fetch
- **`CHANGELOG.md`** — v1.5.0 entry
- **`README.md`** — local servers table updated

### Research Sources

- https://mcpservers.org/
- https://github.com/modelcontextprotocol/servers
- https://www.pulsemcp.com/servers
- https://dev.to/seakai/best-mcp-servers-for-coding-agents-2025-57i7
- https://docs.devin.ai/work-with-devin/deepwiki-mcp

### Quality Checks

- [x] shellcheck clean
- [x] ruff clean
- [x] `docker compose config` valid
- [x] CHANGELOG.md updated
- [x] README.md updated
- [x] Commits follow conventional commit rules
- [x] No secrets in committed files (.env is gitignored)