### PR TITLE
fix(ci): fix release-automation.yml double action prefix, broken JSON brace, and npm-release-core.yml duplicate YAML keys

### DIFF
--- a/.github/workflows/npm-release-core.yml
+++ b/.github/workflows/npm-release-core.yml
@@ -4,20 +4,17 @@
 name: NPM Release - Core Package
 
 on:
-  # Trigger on release branch merges
+  # Trigger on release branch merges or version tags
   push:
     branches: [release/core]
+    tags:
+      - 'core-v*'
     paths:
       - 'package.json'
       - 'src/**'
       - 'README.md'
       - 'LICENSE'
-  
-  # Trigger on version tags
-  push:
-    tags:
-      - 'core-v*'
-  
+
   # Allow manual triggering
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -92,7 +92,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/actions/checkout@v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -180,7 +180,7 @@ jobs:
           client-payload: |
             {
               "repository": "mcp-gateway",
-              "version": "${{ steps.version.outputs.version }",
+              "version": "${{ steps.version.outputs.version }}",
               "package": "mcp-gateway",
               "platform": "pypi"
             }


### PR DESCRIPTION
## Summary

- `release-automation.yml`: fix `actions/actions/checkout@v4` typo → `actions/checkout@v4`
- `release-automation.yml`: fix missing `}}` closing brace in JSON client-payload expression (`"version": "${{ steps.version.outputs.version }"` → `"version": "${{ steps.version.outputs.version }}"` )
- `npm-release-core.yml`: merge duplicate `on.push` YAML keys (invalid YAML — second key overwrites first) into a single valid `on.push` block with both `branches` and `tags` filters

## Test plan
- [ ] Verify `release-automation.yml` parses cleanly with `yamllint`
- [ ] Verify `npm-release-core.yml` YAML is valid and triggers on both branch merges and tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkout action configuration and version interpolation syntax in release automation workflows.

* **Chores**
  * Streamlined release workflow configuration by consolidating release triggers for both branch merges and version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->