### PR TITLE
fix(ci): resolve last 2 CI infra failures

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -27,23 +27,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
+    env:
+      HAS_KEY: ${{ secrets.GITGUARDIAN_API_KEY != '' }}
 
     steps:
       - name: Checkout repository
+        if: env.HAS_KEY == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: GitGuardian Scan
+        if: env.HAS_KEY == 'true'
         uses: GitGuardian/gg-shield-action@v1
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ env.GITGUARDIAN_API_URL }}
         with:
           args: >
-            scan 
-            --all 
-            --verbose 
+            scan
+            --all
+            --verbose
             --exit-code-on-secrets=1
 
       - name: Upload GitGuardian results to GitHub Security
@@ -75,22 +79,26 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    env:
+      HAS_KEY: ${{ secrets.GITGUARDIAN_API_KEY != '' }}
 
     steps:
       - name: Checkout repository
+        if: env.HAS_KEY == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: GitGuardian Monitoring
+        if: env.HAS_KEY == 'true'
         uses: GitGuardian/gg-shield-action@v1
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
           GITGUARDIAN_API_URL: ${{ env.GITGUARDIAN_API_URL }}
         with:
           args: >
-            monitor 
-            --all 
+            monitor
+            --all
             --verbose
 
   workflow-summary:

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -77,6 +77,7 @@ jobs:
           context: .
           file: Dockerfile.tool-router
           push: false
+          load: true
           tags: mcp-gateway:test
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- **GitGuardian**: Skip scan/monitoring steps when `GITGUARDIAN_API_KEY` secret isn't configured — jobs show as skipped instead of failing with a red X
- **Docker buildx**: Add `load: true` to `docker/build-push-action` so the built image is available in the local daemon for the `docker run` test step

## Details

### GitGuardian (`gitguardian.yml`)
Both `gitguardian-scan` and `gitguardian-monitoring` jobs now set a `HAS_KEY` env var from the secret. All gg-shield steps are gated with `if: env.HAS_KEY == 'true'`. The `workflow-summary` job already handles skipped dependencies gracefully.

### Docker build (`release-automation.yml`)
`docker/build-push-action@v5` with buildx creates images in an isolated builder context. Without `load: true`, the image isn't accessible to `docker run`. Adding `load: true` imports the image into the local daemon. Compatible with `cache-to: type=gha`.

## Test plan
- [ ] GitGuardian workflow shows skipped (not failed) since the secret doesn't exist
- [ ] `build-test` job passes — Docker image loads into daemon, `docker run` succeeds
- [ ] All other 13 CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)