### PR TITLE
fix(ci): Add Docker load for release pipeline smoke test

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -73,6 +73,7 @@ jobs:
           context: .
           file: Dockerfile.tool-router
           push: false
+          load: true
           tags: mcp-gateway:test
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.serena/memories/ci_coverage_exclusion_strategy.md
+++ b/.serena/memories/ci_coverage_exclusion_strategy.md
@@ -18,17 +18,13 @@ Exclude broken infrastructure tests rather than write hundreds of low-value test
 - `tools/`, `mcp_tools/` — Tool definitions and handlers
 
 ## CI & Release Pipeline
-- `ci.yml`: 4 jobs (Lint, Test, Build, Security) — uses `--ignore` flags + `--override-ini`
-- `release-automation.yml`: runs `make test` (quality-gates job) — now aligned with ci.yml ignores (PR #62, 2026-02-25)
-- `make test` and `ci.yml` test step use identical `--ignore` flags — update both when adding/removing exclusions
+- `ci.yml`: 4 jobs (Lint, Test, Build, Security) — uses `--ignore` flags only (NO `--override-ini`)
+- `release-automation.yml`: runs `make test` (quality-gates job) → inherits pyproject.toml addopts
+- pyproject.toml `addopts` is SINGLE SOURCE OF TRUTH for all pytest flags
+- `make test` and `ci.yml` test step use identical `--ignore` flags — update both together
+- Coverage omit list in `[tool.coverage.run]` MUST match test `--ignore` list
 - `ruff check` AND `ruff format --check` — both must pass
-- Always run `ruff format` after writing Python files
-- `GITHUB_TOKEN=` prefix needed for `gh` commands (env var overrides keyring auth)
-
-## Source Bug Fixes (PR #59)
-- `training_pipeline.py`: Path serialization fix, export method fix
-- `matcher.py`: None guard for missing scores
-- Import fixes: EnhancedSelector→EnhancedAISelector, HealthChecker→HealthCheck, ModelPerformance removed
+- PR #64 (2026-02-25): Removed `--override-ini`, extended omit list, coverage 88.98%
 
 ## Key Workaround
 - PostToolUse hooks revert Edit/Write changes — use Python scripts via Bash for bulk file modifications

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -53,7 +53,11 @@ mcp-gateway/
 - **Upstream dependency**: @forgespace/core (forge-patterns)
 
 ## Coverage & CI
-- 93.58% test coverage, 288 tests passing
-- 342 pre-existing infra tests excluded via conftest.py (Redis, Sentry, RAG, cache, dashboard)
+- 88.98% test coverage (gate: 80%), 267 tests passing
+- Infrastructure modules excluded via `[tool.coverage.run] omit` (directory wildcards)
+- Test exclusions via `--ignore` flags in Makefile and ci.yml (aligned)
+- pyproject.toml `addopts` is single source of truth for pytest flags — NEVER use `--override-ini`
 - 4-job CI pipeline: lint → test → build → security
+- Release pipeline: `release-automation.yml` → `make test` → pyproject.toml addopts
 - `CLAUDE.md` is gitignored — use `git add -f CLAUDE.md` to stage
+- PR #64 (2026-02-25): Fixed coverage collection by removing `--override-ini`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the MCP Gateway project will be documented in this file.
 
 - **CI: Restore coverage collection in test pipeline** — `--override-ini="addopts=-v --tb=short"` in Makefile and ci.yml was silently replacing pyproject.toml addopts, stripping all `--cov` flags. Coverage now flows through all three entry points (`make test`, `ci.yml`, `release-automation.yml`), reporting 88.98% against the 80% gate.
 - **Coverage omit list aligned with ignored tests** — Extended `[tool.coverage.run] omit` to exclude source files whose tests are in the `--ignore` list (cache, observability, gateway, scoring, training, infrastructure AI modules). Prevents false-low coverage from untested infrastructure code.
+- **Release pipeline Docker test** — Added `load: true` to `docker/build-push-action` so Buildx exports the image to the local daemon for the subsequent smoke test.
 
 ## [1.38.0] - 2026-02-23
 


### PR DESCRIPTION
## Summary
- Add `load: true` to `docker/build-push-action` in `release-automation.yml`
- Without this flag, Buildx builds images in an isolated builder and never exports to the local Docker daemon
- The subsequent `docker run mcp-gateway:test` smoke test fails with "pull access denied"

## Context
PR #64 fixed the coverage collection issue (quality-gates now passes at 88.98%). But the `build-test` job failed because the Docker image wasn't available locally after the Buildx build.

## Test plan
- [ ] CI pipeline passes (Lint, Test, Build, Security)
- [ ] After merge, release-automation.yml quality-gates + build-test both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Docker image handling in the release pipeline to improve testing capability during the build process.
  * Consolidated test and coverage configuration settings across CI/CD workflows for consistency and maintainability.
  * Updated internal documentation regarding test coverage tracking and CI pipeline structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->