### PR TITLE
fix: Rename PyPI package to forge-mcp-gateway

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -158,7 +158,7 @@ jobs:
 
             ### 🔧 Installation
             ```bash
-            pip install mcp-gateway==${{ steps.version.outputs.version }}
+            pip install forge-mcp-gateway==${{ steps.version.outputs.version }}
             ```
 
             ### 📋 Verification
@@ -178,6 +178,6 @@ jobs:
             {
               "repository": "mcp-gateway",
               "version": "${{ steps.version.outputs.version }}",
-              "package": "mcp-gateway",
+              "package": "forge-mcp-gateway",
               "platform": "pypi"
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the MCP Gateway project will be documented in this file.
 - **CI: Restore coverage collection in test pipeline** — `--override-ini="addopts=-v --tb=short"` in Makefile and ci.yml was silently replacing pyproject.toml addopts, stripping all `--cov` flags. Coverage now flows through all three entry points (`make test`, `ci.yml`, `release-automation.yml`), reporting 88.98% against the 80% gate.
 - **Coverage omit list aligned with ignored tests** — Extended `[tool.coverage.run] omit` to exclude source files whose tests are in the `--ignore` list (cache, observability, gateway, scoring, training, infrastructure AI modules). Prevents false-low coverage from untested infrastructure code.
 - **Release pipeline Docker test** — Added `load: true` to `docker/build-push-action` so Buildx exports the image to the local daemon for the subsequent smoke test.
+- **PyPI package rename** — Renamed from `mcp-gateway` (taken) to `forge-mcp-gateway` to enable automated PyPI publishing.
 
 ## [1.38.0] - 2026-02-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mcp-gateway"
+name = "forge-mcp-gateway"
 version = "1.7.0"
 description = "Self-hosted MCP gateway (Context Forge) with tool-router"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Rename package from `mcp-gateway` to `forge-mcp-gateway` in pyproject.toml
- Update release workflow install command and repository dispatch payload
- `mcp-gateway` name is taken on PyPI by another user

## Test plan
- [ ] CI passes (no functional changes)
- [ ] After merge, release-automation.yml publishes to PyPI as `forge-mcp-gateway`

🤖 Generated with [Claude Code](https://claude.com/claude-code)