### PR TITLE
chore: Release v1.7.1 — CI/CD pipeline fixes

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -131,7 +131,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          twine upload dist/*
+          twine upload dist/* --skip-existing
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the MCP Gateway project will be documented in this file.
 
-## [Unreleased]
+## [1.7.1] - 2026-02-25
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forge-mcp-gateway"
-version = "1.7.0"
+version = "1.7.1"
 description = "Self-hosted MCP gateway (Context Forge) with tool-router"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version to 1.7.1
- Add `--skip-existing` to twine upload for idempotent re-runs
- Promote CHANGELOG unreleased section to 1.7.1

## Changes in v1.7.1
- **PR #64**: Restore coverage collection (88.98% vs 80% gate)
- **PR #65**: Docker smoke test fix (Buildx `load: true`)
- **PR #66**: PyPI package renamed to `forge-mcp-gateway`
- **PR #67**: Release permissions + modernized GitHub Release action

## Test plan
- [ ] CI passes
- [ ] After merge, full release pipeline completes end-to-end
- [ ] `forge-mcp-gateway` v1.7.1 published to PyPI
- [ ] GitHub Release v1.7.1 created

🤖 Generated with [Claude Code](https://claude.com/claude-code)