### PR TITLE
fix(ci): Update required checks to match actual CI job names

### DIFF
--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -47,7 +47,7 @@ mcp-gateway/
 
 ## Package Info
 - **Name**: mcp-gateway
-- **Version**: 1.7.0
+- **Version**: 1.7.1
 - **Python package**: mcp-gateway (setuptools)
 - **npm package**: npx wrapper entry point
 - **Upstream dependency**: @forgespace/core (forge-patterns)
@@ -61,3 +61,7 @@ mcp-gateway/
 - Release pipeline: `release-automation.yml` → `make test` → pyproject.toml addopts
 - `CLAUDE.md` is gitignored — use `git add -f CLAUDE.md` to stage
 - PR #64 (2026-02-25): Fixed coverage collection by removing `--override-ini`
+- PR #68 (2026-02-25): Release v1.7.1 — CI/CD pipeline fixes
+- v1.7.1 released: tag + GitHub Release created via automated pipeline
+- Known: repository-dispatch step needs PAT for cross-repo (Forge-Space/core), GitGuardian API key expired
+- Required checks mismatch: "CI Pipeline"/"CodeQL Security Analysis" don't match actual job names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the MCP Gateway project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **GitHub ruleset required checks** — Updated main-branch-protection required checks from "CI Pipeline"/"CodeQL Security Analysis" (workflow names) to "Test"/"Build"/"Lint" (actual job names). PRs no longer require admin bypass to merge.
+
 ## [1.7.1] - 2026-02-25
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ apps/                 # Legacy structure (DO NOT reference in CI)
 - `GITHUB_TOKEN= gh ...` required (env var overrides keyring)
 - `CLAUDE.md` is gitignored — use `git add -f CLAUDE.md` to commit changes
 - GitGuardian workflow: `.github/workflows/gitguardian.yml` — `GITGUARDIAN_API_KEY` secret may be invalid (check secret first if scan fails)
+- Main branch required checks: "Test", "Build", "Lint" (must match CI job `name:` fields exactly)
+- GitGuardian `GITGUARDIAN_API_KEY` secret is expired — scan fails but is not a required check
 - Main branch ruleset has no bypass actors by default — temporarily add via API for urgent merges
 
 ## Documentation Governance


### PR DESCRIPTION
## Summary
- Updated main-branch-protection GitHub ruleset required checks from workflow names ("CI Pipeline", "CodeQL Security Analysis") to actual CI job names ("Test", "Build", "Lint")
- This eliminates the need for admin bypass on every PR merge
- Updated CLAUDE.md with correct required check names and GitGuardian API key status

## Context
Every PR merge required `--admin` bypass because the required check names didn't match what GitHub Actions reports. The CI workflow `name: CI Pipeline` creates jobs with `name: Lint`, `name: Test`, `name: Build` — GitHub status checks use the job-level names, not the workflow name.

## Test plan
- [x] Ruleset already updated via GitHub API
- [ ] This PR should merge without admin bypass (validates the fix)
- [x] CLAUDE.md documents the correct check names

🤖 Generated with [Claude Code](https://claude.com/claude-code)