### PR TITLE
test: Fix and re-enable 124 excluded tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
           pytest tool_router/tests/ dribbble_mcp/tests/ \
             --ignore=tool_router/tests/performance \
             --ignore=tool_router/tests/integration \
-            --ignore=tool_router/tests/test_observability.py \
-            --ignore=tool_router/tests/test_observability \
             --ignore=tool_router/tests/test_training \
             --ignore=tool_router/tests/training \
             --ignore=tool_router/tests/unit/test_training_pipeline.py \
@@ -64,7 +62,6 @@ jobs:
             --ignore=tool_router/tests/unit/test_ui_specialist.py \
             --ignore=tool_router/tests/test_cache_basic.py \
             --ignore=tool_router/tests/test_cache_compliance.py \
-            --ignore=dribbble_mcp/tests/test_health_check.py \
             --timeout=30 --maxfail=10
 
   build:

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,6 @@ test: ## Run tests (replaces test, test-coverage)
 	pytest tool_router/tests/ dribbble_mcp/tests/ \
 		--ignore=tool_router/tests/performance \
 		--ignore=tool_router/tests/integration \
-		--ignore=tool_router/tests/test_observability.py \
-		--ignore=tool_router/tests/test_observability \
 		--ignore=tool_router/tests/test_training \
 		--ignore=tool_router/tests/training \
 		--ignore=tool_router/tests/unit/test_training_pipeline.py \
@@ -133,7 +131,6 @@ test: ## Run tests (replaces test, test-coverage)
 		--ignore=tool_router/tests/unit/test_ui_specialist.py \
 		--ignore=tool_router/tests/test_cache_basic.py \
 		--ignore=tool_router/tests/test_cache_compliance.py \
-		--ignore=dribbble_mcp/tests/test_health_check.py \
 		--timeout=30 --maxfail=10
 
 deps: ## Dependency management (replaces deps-check, deps-update, pre-commit-install)

--- a/dribbble_mcp/tests/test_health_check.py
+++ b/dribbble_mcp/tests/test_health_check.py
@@ -75,6 +75,7 @@ class TestHealthCheck:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                check=False,
             )
 
     @patch("urllib.request.urlopen")
@@ -161,5 +162,6 @@ class TestHealthCheck:
                 capture_output=True,
                 text=True,
                 timeout=5,
+                check=False,
             )
             mock_exit.assert_called_once_with(0)


### PR DESCRIPTION
## Summary
- Rewrite observability health tests for new API (`HTTPGatewayClient` + `GatewayConfig` replaced `requests` + `ToolRouterConfig`) — 21 tests
- Fix dribbble health check mock assertions (add `check=False` param) — 10 tests
- Re-enable `test_observability/` and `dribbble health_check` in CI + Makefile

## Impact
- **Test count**: 184 → 308 passing (+124 tests)
- **Coverage**: 88.98% (above 80% threshold)
- **0 failures**, 1 skip, 10 warnings (deprecation only)

## Still excluded (future work)
- `test_cache_basic.py` / `test_cache_compliance.py` — import refactor needed
- `unit/test_specialist_coordinator.py` — assertion mismatch (1 test)
- `unit/test_ui_specialist.py` — assertion mismatch (1 test)
- `training/` — experimental pipeline
- `integration/` — infrastructure tests
- `performance/` — no tests collected

## Test plan
- [x] `make test` passes locally (308 passed, 1 skipped)
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green (Test, Build, Lint jobs)