### PR TITLE
chore: Release v1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the MCP Gateway project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.5] - 2026-02-27
+
 ### Security
 
 - **Fix hono IP spoofing vulnerability** — Upgraded `hono` 4.12.0 → 4.12.3 to patch authentication bypass via IP spoofing in AWS Lambda ALB conninfo (GHSA-xh87-mx6m-69f3). Closes #81.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forge-mcp-gateway"
-version = "1.7.4"
+version = "1.7.5"
 description = "Self-hosted MCP gateway (Context Forge) with tool-router"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version to 1.7.5
- Move CHANGELOG Unreleased section to v1.7.5

### What's in v1.7.5
- **Security**: hono IP spoofing fix (4.12.0 → 4.12.3, GHSA-xh87-mx6m-69f3)
- **Tests**: Final restoration — 1670 tests, zero conftest exclusions (+103 from v1.7.4)
- **Fixed**: 6 source bugs (RedisCache fallback, knowledge base SQL, evaluation metadata)

## Test plan
- [ ] CI passes (lint, test, build, security)
- [ ] Squash merge, then manually tag + release

Generated with [Claude Code](https://claude.com/claude-code)