### PR TITLE
feat: IDP security foundation — jose JWT, RBAC, audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the MCP Gateway project will be documented in this file.
 
+## [1.8.0] - 2026-03-06
+
+### Added
+- **Jose JWT authentication** — `JoseJWTValidator` with JWKS caching, Supabase-issued token validation, configurable issuer/audience
+- **RBAC authorization** — `RBACEvaluator` with 4 roles (admin, developer, viewer, user), permission-based access control, wildcard support
+- **Audit events API** — `/api/audit/events` endpoint for governance audit trail
+- 36 new tests for auth and authorization modules
+
+### Changed
+- **Security config** — `authentication.required` now `true`, `enable_jose_auth` enabled, JWT-only methods with legacy fallback
+- **Authorization** — Enabled by default with role-based permissions for components, templates, policies, scorecards
+- **Branding** — Replace claudecodeui icons with Forge Space Modern Horn monogram; `--brand-error` and `--brand-inactive` CSS variables (PR #97)
+
 ## [1.7.8] - 2026-03-01
 
 ### Fixed

--- a/config/security.yaml
+++ b/config/security.yaml
@@ -50,25 +50,32 @@ security:
 
   # Authentication Settings
   authentication:
-    required: false
-    methods: ["api_key", "jwt", "session"]
+    required: true
+    enable_jose_auth: true
+    methods: ["jwt"]
+    jwt_issuer: "${SUPABASE_JWT_ISSUER}"
+    jwks_url: "${SUPABASE_JWKS_URL}"
+    jwt_audience: null
+    fallback_to_legacy: true  # Keep PyJWT as fallback for 2 weeks
     api_key_header: "X-API-Key"
-    jwt_secret_env: "JWT_SECRET"
     session_timeout: 3600 # seconds
 
   # Authorization Settings
   authorization:
-    enabled: false
+    enabled: true
     default_role: "user"
     roles:
-      - name: "user"
-        permissions: ["read", "execute_basic"]
-      - name: "developer"
-        permissions: ["read", "execute", "configure"]
       - name: "admin"
-        permissions: ["read", "execute", "configure", "manage"]
-      - name: "enterprise"
-        permissions: ["read", "execute", "configure", "manage", "admin"]
+        permissions: ["*"]
+      - name: "developer"
+        permissions: ["component:read", "component:create", "component:update",
+                       "template:read", "template:create", "system:read",
+                       "audit:read", "policy:read", "scorecard:read", "tool:execute"]
+      - name: "user"
+        permissions: ["component:read", "component:create", "component:update",
+                       "template:read", "scorecard:read", "tool:execute"]
+      - name: "guest"
+        permissions: ["component:read", "template:read"]
 
   # Audit Logging
   audit_logging:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forge-mcp-gateway"
-version = "1.7.8"
+version = "1.8.0"
 description = "Self-hosted MCP gateway (Context Forge) with tool-router"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -22,6 +22,7 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "redis>=5.0.0",
     "requests>=2.31.0",
+    "python-jose[cryptography]>=3.3.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,7 @@ cachetools>=2.0.0
 
 # Redis for distributed caching
 redis>=5.0.0
+
+# JWT validation (jose) and HTTP client
+python-jose[cryptography]>=3.3.0
+httpx>=0.27.0

--- a/tool_router/api/audit.py
+++ b/tool_router/api/audit.py
@@ -1,0 +1,103 @@
+"""Audit events API for MCP Gateway governance."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/audit", tags=["audit"])
+
+
+class AuditEvent(BaseModel):
+    timestamp: str
+    event_type: str
+    severity: str
+    user_id: str | None = None
+    request_id: str | None = None
+    ip_address: str | None = None
+    details: dict[str, Any] = {}
+
+
+class AuditEventsResponse(BaseModel):
+    events: list[AuditEvent]
+    total: int
+    page: int
+    page_size: int
+
+
+def _get_audit_logger():
+    """Get the security audit logger singleton."""
+    from tool_router.security import SecurityAuditLogger
+
+    return SecurityAuditLogger()
+
+
+@router.get("/events", response_model=AuditEventsResponse)
+async def get_audit_events(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    event_type: str | None = Query(None),
+    severity: str | None = Query(None),
+    user_id: str | None = Query(None),
+) -> AuditEventsResponse:
+    """Retrieve audit events. Requires admin role."""
+    audit_logger = _get_audit_logger()
+
+    try:
+        summary = audit_logger.get_security_summary()
+    except Exception as exc:
+        logger.error("Failed to retrieve audit events: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to retrieve audit events",
+        ) from exc
+
+    events: list[AuditEvent] = []
+    for event_data in summary.get("recent_events", []):
+        event = AuditEvent(
+            timestamp=event_data.get("timestamp", ""),
+            event_type=event_data.get("event_type", "unknown"),
+            severity=event_data.get("severity", "info"),
+            user_id=event_data.get("user_id"),
+            request_id=event_data.get("request_id"),
+            ip_address=event_data.get("ip_address"),
+            details=event_data.get("details", {}),
+        )
+        if event_type and event.event_type != event_type:
+            continue
+        if severity and event.severity != severity:
+            continue
+        if user_id and event.user_id != user_id:
+            continue
+        events.append(event)
+
+    total = len(events)
+    start = (page - 1) * page_size
+    paginated = events[start : start + page_size]
+
+    return AuditEventsResponse(
+        events=paginated,
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/summary")
+async def get_audit_summary() -> dict[str, Any]:
+    """Get audit summary statistics. Requires admin role."""
+    audit_logger = _get_audit_logger()
+    try:
+        return audit_logger.get_security_summary()
+    except Exception as exc:
+        logger.error("Failed to retrieve audit summary: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to retrieve audit summary",
+        ) from exc

--- a/tool_router/security/__init__.py
+++ b/tool_router/security/__init__.py
@@ -11,6 +11,14 @@ Provides comprehensive security features including:
 from __future__ import annotations
 
 from .audit_logger import SecurityAuditLogger
+from .auth import AuthenticationError, JoseJWTValidator, JWTPayload
+from .authorization import (
+    AuthorizationError,
+    AuthzResult,
+    Permission,
+    RBACEvaluator,
+    Role,
+)
 from .input_validator import InputValidator, SecurityValidationResult, ValidationLevel
 from .rate_limiter import RateLimitConfig, RateLimiter, RateLimitResult
 from .security_middleware import (
@@ -21,10 +29,18 @@ from .security_middleware import (
 
 
 __all__ = [
+    "AuthenticationError",
+    "AuthorizationError",
+    "AuthzResult",
     "InputValidator",
+    "JoseJWTValidator",
+    "JWTPayload",
+    "Permission",
+    "RBACEvaluator",
     "RateLimitConfig",
     "RateLimitResult",
     "RateLimiter",
+    "Role",
     "SecurityAuditLogger",
     "SecurityCheckResult",
     "SecurityContext",

--- a/tool_router/security/auth.py
+++ b/tool_router/security/auth.py
@@ -1,0 +1,140 @@
+"""Jose JWT validation for Supabase-issued tokens."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from jose import JWTError, jwt
+from jose.exceptions import ExpiredSignatureError
+
+
+logger = logging.getLogger(__name__)
+
+JWKS_CACHE_TTL = 3600  # 1 hour
+
+
+@dataclass
+class JWTPayload:
+    """Validated JWT payload."""
+
+    sub: str
+    role: str
+    permissions: list[str] = field(default_factory=list)
+    email: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+class AuthenticationError(Exception):
+    """Raised when JWT validation fails."""
+
+    def __init__(self, message: str, status_code: int = 401):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class JoseJWTValidator:
+    """Validates Supabase JWTs using JWKS and python-jose."""
+
+    def __init__(
+        self,
+        jwks_url: str,
+        jwt_issuer: str,
+        audience: str | None = None,
+        algorithms: list[str] | None = None,
+    ):
+        self.jwks_url = jwks_url
+        self.jwt_issuer = jwt_issuer
+        self.audience = audience
+        self.algorithms = algorithms or ["RS256"]
+        self._jwks_cache: dict[str, Any] | None = None
+        self._jwks_cache_time: float = 0
+
+    def _fetch_jwks(self) -> dict[str, Any]:
+        now = time.time()
+        if self._jwks_cache and (now - self._jwks_cache_time) < JWKS_CACHE_TTL:
+            return self._jwks_cache
+
+        try:
+            resp = httpx.get(self.jwks_url, timeout=10)
+            resp.raise_for_status()
+            self._jwks_cache = resp.json()
+            self._jwks_cache_time = now
+            logger.info("JWKS refreshed from %s", self.jwks_url)
+            return self._jwks_cache
+        except Exception as exc:
+            if self._jwks_cache:
+                logger.warning("JWKS refresh failed, using stale cache: %s", exc)
+                return self._jwks_cache
+            raise AuthenticationError(f"Failed to fetch JWKS: {exc}") from exc
+
+    def validate(self, token: str) -> JWTPayload:
+        """Validate a JWT and extract claims."""
+        if not token:
+            raise AuthenticationError("Missing authentication token")
+
+        jwks = self._fetch_jwks()
+
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+        except JWTError as exc:
+            raise AuthenticationError(f"Invalid token header: {exc}") from exc
+
+        kid = unverified_header.get("kid")
+        rsa_key: dict[str, str] = {}
+        for key in jwks.get("keys", []):
+            if key.get("kid") == kid:
+                rsa_key = {
+                    "kty": key["kty"],
+                    "kid": key["kid"],
+                    "use": key.get("use", "sig"),
+                    "n": key["n"],
+                    "e": key["e"],
+                }
+                break
+
+        if not rsa_key:
+            raise AuthenticationError("Unable to find matching signing key")
+
+        try:
+            payload = jwt.decode(
+                token,
+                rsa_key,
+                algorithms=self.algorithms,
+                issuer=self.jwt_issuer,
+                audience=self.audience,
+                options={"verify_aud": self.audience is not None},
+            )
+        except ExpiredSignatureError:
+            raise AuthenticationError("Token has expired")
+        except JWTError as exc:
+            raise AuthenticationError(f"Invalid token: {exc}") from exc
+
+        sub = payload.get("sub")
+        if not sub:
+            raise AuthenticationError("Token missing subject claim")
+
+        role = payload.get("role", payload.get("user_role", "user"))
+        permissions = payload.get("permissions", [])
+        if isinstance(permissions, str):
+            permissions = [permissions]
+
+        return JWTPayload(
+            sub=sub,
+            role=role,
+            permissions=permissions,
+            email=payload.get("email"),
+            raw=payload,
+        )
+
+    def extract_token(self, authorization: str | None) -> str:
+        """Extract Bearer token from Authorization header."""
+        if not authorization:
+            raise AuthenticationError("Missing Authorization header")
+        parts = authorization.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise AuthenticationError("Invalid Authorization header format")
+        return parts[1]

--- a/tool_router/security/authorization.py
+++ b/tool_router/security/authorization.py
@@ -1,0 +1,176 @@
+"""RBAC authorization evaluator for MCP Gateway."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+class Role(StrEnum):
+    ADMIN = "admin"
+    DEVELOPER = "developer"
+    USER = "user"
+    GUEST = "guest"
+
+
+class Permission(StrEnum):
+    COMPONENT_READ = "component:read"
+    COMPONENT_CREATE = "component:create"
+    COMPONENT_UPDATE = "component:update"
+    COMPONENT_DELETE = "component:delete"
+    TEMPLATE_READ = "template:read"
+    TEMPLATE_CREATE = "template:create"
+    TEMPLATE_UPDATE = "template:update"
+    TEMPLATE_DELETE = "template:delete"
+    SYSTEM_READ = "system:read"
+    SYSTEM_ADMIN = "system:admin"
+    USER_MANAGE = "user:manage"
+    AUDIT_READ = "audit:read"
+    POLICY_READ = "policy:read"
+    POLICY_WRITE = "policy:write"
+    SCORECARD_READ = "scorecard:read"
+    TOOL_EXECUTE = "tool:execute"
+
+
+ROLE_PERMISSIONS: dict[Role, list[Permission]] = {
+    Role.ADMIN: list(Permission),
+    Role.DEVELOPER: [
+        Permission.COMPONENT_READ,
+        Permission.COMPONENT_CREATE,
+        Permission.COMPONENT_UPDATE,
+        Permission.TEMPLATE_READ,
+        Permission.TEMPLATE_CREATE,
+        Permission.SYSTEM_READ,
+        Permission.AUDIT_READ,
+        Permission.POLICY_READ,
+        Permission.SCORECARD_READ,
+        Permission.TOOL_EXECUTE,
+    ],
+    Role.USER: [
+        Permission.COMPONENT_READ,
+        Permission.COMPONENT_CREATE,
+        Permission.COMPONENT_UPDATE,
+        Permission.TEMPLATE_READ,
+        Permission.SCORECARD_READ,
+        Permission.TOOL_EXECUTE,
+    ],
+    Role.GUEST: [
+        Permission.COMPONENT_READ,
+        Permission.TEMPLATE_READ,
+    ],
+}
+
+RESOURCE_ACTION_MAP: dict[str, Permission] = {
+    "tools/call": Permission.TOOL_EXECUTE,
+    "tools/list": Permission.COMPONENT_READ,
+    "audit/events": Permission.AUDIT_READ,
+    "policies/read": Permission.POLICY_READ,
+    "policies/write": Permission.POLICY_WRITE,
+    "scorecards/read": Permission.SCORECARD_READ,
+    "system/admin": Permission.SYSTEM_ADMIN,
+    "users/manage": Permission.USER_MANAGE,
+}
+
+
+class AuthorizationError(Exception):
+    """Raised when RBAC check fails."""
+
+    def __init__(self, message: str, status_code: int = 403):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass
+class AuthzResult:
+    """Result of an authorization check."""
+
+    allowed: bool
+    role: Role
+    required_permission: Permission | None = None
+    reason: str | None = None
+
+
+class RBACEvaluator:
+    """Role-based access control evaluator."""
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        self.enabled = True
+        if config:
+            self.enabled = config.get("enabled", True)
+
+    def resolve_role(self, role_str: str | None) -> Role:
+        """Resolve a string role to the Role enum, defaulting to GUEST."""
+        if not role_str:
+            return Role.GUEST
+        try:
+            return Role(role_str.lower())
+        except ValueError:
+            logger.warning("Unknown role '%s', defaulting to GUEST", role_str)
+            return Role.GUEST
+
+    def check_permission(
+        self,
+        user_role: Role,
+        permission: Permission,
+    ) -> bool:
+        """Check if a role has the given permission."""
+        if not self.enabled:
+            return True
+        allowed_permissions = ROLE_PERMISSIONS.get(user_role, [])
+        return permission in allowed_permissions
+
+    def check_resource_access(
+        self,
+        user_role: Role,
+        resource: str,
+        action: str | None = None,
+    ) -> AuthzResult:
+        """Check access to a resource/action pair."""
+        if not self.enabled:
+            return AuthzResult(allowed=True, role=user_role)
+
+        lookup_key = f"{resource}/{action}" if action else resource
+        required = RESOURCE_ACTION_MAP.get(lookup_key)
+
+        if required is None:
+            required = RESOURCE_ACTION_MAP.get(resource)
+
+        if required is None:
+            return AuthzResult(
+                allowed=True,
+                role=user_role,
+                reason="No permission mapping for resource",
+            )
+
+        allowed = self.check_permission(user_role, required)
+        return AuthzResult(
+            allowed=allowed,
+            role=user_role,
+            required_permission=required,
+            reason=None if allowed else f"Role {user_role.value} lacks {required.value}",
+        )
+
+    def require_permission(
+        self,
+        user_role: Role,
+        permission: Permission,
+    ) -> None:
+        """Raise AuthorizationError if permission check fails."""
+        if not self.check_permission(user_role, permission):
+            raise AuthorizationError(f"Insufficient permissions: {permission.value} required")
+
+    def require_resource_access(
+        self,
+        user_role: Role,
+        resource: str,
+        action: str | None = None,
+    ) -> None:
+        """Raise AuthorizationError if resource access check fails."""
+        result = self.check_resource_access(user_role, resource, action)
+        if not result.allowed:
+            raise AuthorizationError(result.reason or "Access denied")

--- a/tool_router/tests/test_auth.py
+++ b/tool_router/tests/test_auth.py
@@ -1,0 +1,312 @@
+"""Tests for JoseJWTValidator."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tool_router.security.auth import (
+    AuthenticationError,
+    JoseJWTValidator,
+    JWTPayload,
+)
+
+
+MOCK_JWKS = {
+    "keys": [
+        {
+            "kty": "RSA",
+            "kid": "test-key-id",
+            "use": "sig",
+            "n": "test-n",
+            "e": "AQAB",
+        }
+    ]
+}
+
+MOCK_JWKS_URL = "https://example.com/.well-known/jwks.json"
+MOCK_ISSUER = "https://example.com"
+MOCK_AUDIENCE = "test-audience"
+
+
+@pytest.fixture
+def validator() -> JoseJWTValidator:
+    """Create a JoseJWTValidator instance."""
+    return JoseJWTValidator(
+        jwks_url=MOCK_JWKS_URL,
+        jwt_issuer=MOCK_ISSUER,
+        audience=MOCK_AUDIENCE,
+    )
+
+
+@pytest.fixture
+def mock_jwks_response():
+    """Mock httpx.get response for JWKS endpoint."""
+    with patch("tool_router.security.auth.httpx.get") as mock_get:
+        mock_response = Mock()
+        mock_response.json.return_value = MOCK_JWKS
+        mock_response.raise_for_status = Mock()
+        mock_get.return_value = mock_response
+        yield mock_get
+
+
+def test_valid_jwt_validation(validator: JoseJWTValidator, mock_jwks_response):
+    """Test successful JWT validation with mocked JWKS endpoint."""
+    valid_payload = {
+        "sub": "user-123",
+        "role": "developer",
+        "permissions": ["component:read", "tool:execute"],
+        "email": "test@example.com",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = valid_payload
+
+            token = "mock.jwt.token"
+            result = validator.validate(token)
+
+            assert isinstance(result, JWTPayload)
+            assert result.sub == "user-123"
+            assert result.role == "developer"
+            assert result.permissions == ["component:read", "tool:execute"]
+            assert result.email == "test@example.com"
+            assert result.raw == valid_payload
+
+            mock_jwks_response.assert_called_once()
+            mock_decode.assert_called_once()
+
+
+def test_expired_token_raises_authentication_error(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that expired token raises AuthenticationError."""
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            from jose.exceptions import ExpiredSignatureError
+
+            mock_decode.side_effect = ExpiredSignatureError("Token expired")
+
+            token = "expired.jwt.token"
+            with pytest.raises(AuthenticationError) as exc_info:
+                validator.validate(token)
+
+            assert "Token has expired" in str(exc_info.value)
+            assert exc_info.value.status_code == 401
+
+
+def test_invalid_signature_raises_authentication_error(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that invalid signature raises AuthenticationError."""
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            from jose import JWTError
+
+            mock_decode.side_effect = JWTError("Invalid signature")
+
+            token = "invalid.jwt.token"
+            with pytest.raises(AuthenticationError) as exc_info:
+                validator.validate(token)
+
+            assert "Invalid token" in str(exc_info.value)
+            assert exc_info.value.status_code == 401
+
+
+def test_jwks_cache_hit(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that second validation uses cached JWKS."""
+    valid_payload = {
+        "sub": "user-123",
+        "role": "user",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = valid_payload
+
+            token = "mock.jwt.token"
+            validator.validate(token)
+            validator.validate(token)
+
+            assert mock_jwks_response.call_count == 1
+
+
+def test_missing_subject_claim(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that missing subject claim raises AuthenticationError."""
+    invalid_payload = {
+        "role": "user",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = invalid_payload
+
+            token = "mock.jwt.token"
+            with pytest.raises(AuthenticationError) as exc_info:
+                validator.validate(token)
+
+            assert "Token missing subject claim" in str(exc_info.value)
+
+
+def test_extract_token_valid_header(validator: JoseJWTValidator):
+    """Test extract_token with valid Authorization header."""
+    auth_header = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    token = validator.extract_token(auth_header)
+    assert token == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+
+
+def test_extract_token_missing_header(validator: JoseJWTValidator):
+    """Test extract_token with missing Authorization header."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        validator.extract_token(None)
+    assert "Missing Authorization header" in str(exc_info.value)
+
+
+def test_extract_token_invalid_format(validator: JoseJWTValidator):
+    """Test extract_token with invalid Authorization header format."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        validator.extract_token("InvalidFormat token")
+    assert "Invalid Authorization header format" in str(exc_info.value)
+
+
+def test_extract_token_missing_bearer_prefix(validator: JoseJWTValidator):
+    """Test extract_token with missing Bearer prefix."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        validator.extract_token("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+    assert "Invalid Authorization header format" in str(exc_info.value)
+
+
+def test_missing_kid_in_jwks(validator: JoseJWTValidator, mock_jwks_response):
+    """Test validation fails when kid not found in JWKS."""
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "unknown-key-id"}
+
+        token = "mock.jwt.token"
+        with pytest.raises(AuthenticationError) as exc_info:
+            validator.validate(token)
+
+        assert "Unable to find matching signing key" in str(exc_info.value)
+
+
+def test_empty_token_raises_error(validator: JoseJWTValidator):
+    """Test that empty token raises AuthenticationError."""
+    with pytest.raises(AuthenticationError) as exc_info:
+        validator.validate("")
+    assert "Missing authentication token" in str(exc_info.value)
+
+
+def test_permissions_as_string(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that permissions string is converted to list."""
+    valid_payload = {
+        "sub": "user-123",
+        "role": "user",
+        "permissions": "component:read",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = valid_payload
+
+            token = "mock.jwt.token"
+            result = validator.validate(token)
+
+            assert result.permissions == ["component:read"]
+
+
+def test_role_fallback_to_user_role(validator: JoseJWTValidator, mock_jwks_response):
+    """Test role fallback from user_role claim if role not present."""
+    valid_payload = {
+        "sub": "user-123",
+        "user_role": "admin",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = valid_payload
+
+            token = "mock.jwt.token"
+            result = validator.validate(token)
+
+            assert result.role == "admin"
+
+
+def test_jwks_cache_expiry(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that JWKS cache expires after TTL."""
+    valid_payload = {
+        "sub": "user-123",
+        "role": "user",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = valid_payload
+
+            token = "mock.jwt.token"
+            validator.validate(token)
+
+            validator._jwks_cache_time = time.time() - 3601
+
+            validator.validate(token)
+
+            assert mock_jwks_response.call_count == 2
+
+
+def test_jwks_fetch_failure_with_stale_cache(validator: JoseJWTValidator, mock_jwks_response):
+    """Test that stale cache is used when JWKS fetch fails."""
+    validator._jwks_cache = MOCK_JWKS
+    validator._jwks_cache_time = time.time() - 3601
+
+    mock_jwks_response.side_effect = Exception("Network error")
+
+    valid_payload = {
+        "sub": "user-123",
+        "role": "user",
+        "iss": MOCK_ISSUER,
+        "aud": MOCK_AUDIENCE,
+        "exp": int(time.time()) + 3600,
+    }
+
+    with patch("tool_router.security.auth.jwt.get_unverified_header") as mock_header:
+        mock_header.return_value = {"kid": "test-key-id"}
+        with patch("tool_router.security.auth.jwt.decode") as mock_decode:
+            mock_decode.return_value = valid_payload
+
+            token = "mock.jwt.token"
+            result = validator.validate(token)
+            assert result.sub == "user-123"
+
+
+def test_jwks_fetch_failure_without_cache(validator: JoseJWTValidator):
+    """Test that JWKS fetch failure without cache raises AuthenticationError."""
+    with patch("tool_router.security.auth.httpx.get") as mock_get:
+        mock_get.side_effect = Exception("Network error")
+
+        token = "mock.jwt.token"
+        with pytest.raises(AuthenticationError) as exc_info:
+            validator.validate(token)
+
+        assert "Failed to fetch JWKS" in str(exc_info.value)

--- a/tool_router/tests/test_authorization.py
+++ b/tool_router/tests/test_authorization.py
@@ -1,0 +1,275 @@
+"""Tests for RBACEvaluator."""
+
+from __future__ import annotations
+
+import pytest
+
+from tool_router.security.authorization import (
+    ROLE_PERMISSIONS,
+    AuthorizationError,
+    AuthzResult,
+    Permission,
+    RBACEvaluator,
+    Role,
+)
+
+
+@pytest.fixture
+def evaluator() -> RBACEvaluator:
+    """Create an enabled RBACEvaluator instance."""
+    return RBACEvaluator(config={"enabled": True})
+
+
+@pytest.fixture
+def disabled_evaluator() -> RBACEvaluator:
+    """Create a disabled RBACEvaluator instance."""
+    return RBACEvaluator(config={"enabled": False})
+
+
+def test_admin_has_all_permissions(evaluator: RBACEvaluator):
+    """Test that admin role has all permissions."""
+    admin_permissions = ROLE_PERMISSIONS[Role.ADMIN]
+    assert len(admin_permissions) == len(Permission)
+
+    for permission in Permission:
+        assert evaluator.check_permission(Role.ADMIN, permission)
+
+
+def test_developer_permissions(evaluator: RBACEvaluator):
+    """Test developer role permissions."""
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.COMPONENT_READ)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.COMPONENT_CREATE)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.COMPONENT_UPDATE)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.TEMPLATE_READ)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.TEMPLATE_CREATE)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.SYSTEM_READ)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.AUDIT_READ)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.POLICY_READ)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.SCORECARD_READ)
+    assert evaluator.check_permission(Role.DEVELOPER, Permission.TOOL_EXECUTE)
+
+    assert not evaluator.check_permission(Role.DEVELOPER, Permission.COMPONENT_DELETE)
+    assert not evaluator.check_permission(Role.DEVELOPER, Permission.TEMPLATE_DELETE)
+    assert not evaluator.check_permission(Role.DEVELOPER, Permission.SYSTEM_ADMIN)
+    assert not evaluator.check_permission(Role.DEVELOPER, Permission.USER_MANAGE)
+    assert not evaluator.check_permission(Role.DEVELOPER, Permission.POLICY_WRITE)
+
+
+def test_user_permissions(evaluator: RBACEvaluator):
+    """Test user role permissions."""
+    assert evaluator.check_permission(Role.USER, Permission.COMPONENT_READ)
+    assert evaluator.check_permission(Role.USER, Permission.COMPONENT_CREATE)
+    assert evaluator.check_permission(Role.USER, Permission.COMPONENT_UPDATE)
+    assert evaluator.check_permission(Role.USER, Permission.TEMPLATE_READ)
+    assert evaluator.check_permission(Role.USER, Permission.SCORECARD_READ)
+    assert evaluator.check_permission(Role.USER, Permission.TOOL_EXECUTE)
+
+    assert not evaluator.check_permission(Role.USER, Permission.COMPONENT_DELETE)
+    assert not evaluator.check_permission(Role.USER, Permission.TEMPLATE_CREATE)
+    assert not evaluator.check_permission(Role.USER, Permission.TEMPLATE_UPDATE)
+    assert not evaluator.check_permission(Role.USER, Permission.SYSTEM_READ)
+    assert not evaluator.check_permission(Role.USER, Permission.AUDIT_READ)
+    assert not evaluator.check_permission(Role.USER, Permission.POLICY_READ)
+
+
+def test_guest_only_read_permissions(evaluator: RBACEvaluator):
+    """Test that guest role only has read permissions."""
+    assert evaluator.check_permission(Role.GUEST, Permission.COMPONENT_READ)
+    assert evaluator.check_permission(Role.GUEST, Permission.TEMPLATE_READ)
+
+    assert not evaluator.check_permission(Role.GUEST, Permission.COMPONENT_CREATE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.COMPONENT_UPDATE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.COMPONENT_DELETE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.TEMPLATE_CREATE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.TEMPLATE_UPDATE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.TEMPLATE_DELETE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.SYSTEM_READ)
+    assert not evaluator.check_permission(Role.GUEST, Permission.SYSTEM_ADMIN)
+    assert not evaluator.check_permission(Role.GUEST, Permission.USER_MANAGE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.AUDIT_READ)
+    assert not evaluator.check_permission(Role.GUEST, Permission.POLICY_READ)
+    assert not evaluator.check_permission(Role.GUEST, Permission.POLICY_WRITE)
+    assert not evaluator.check_permission(Role.GUEST, Permission.SCORECARD_READ)
+    assert not evaluator.check_permission(Role.GUEST, Permission.TOOL_EXECUTE)
+
+
+def test_resolve_role_valid(evaluator: RBACEvaluator):
+    """Test resolve_role with valid role strings."""
+    assert evaluator.resolve_role("admin") == Role.ADMIN
+    assert evaluator.resolve_role("developer") == Role.DEVELOPER
+    assert evaluator.resolve_role("user") == Role.USER
+    assert evaluator.resolve_role("guest") == Role.GUEST
+
+
+def test_resolve_role_unknown_defaults_to_guest(evaluator: RBACEvaluator):
+    """Test that unknown role defaults to GUEST."""
+    assert evaluator.resolve_role("unknown") == Role.GUEST
+    assert evaluator.resolve_role("invalid_role") == Role.GUEST
+    assert evaluator.resolve_role("") == Role.GUEST
+    assert evaluator.resolve_role(None) == Role.GUEST
+
+
+def test_require_permission_success(evaluator: RBACEvaluator):
+    """Test require_permission does not raise when permission granted."""
+    evaluator.require_permission(Role.ADMIN, Permission.SYSTEM_ADMIN)
+    evaluator.require_permission(Role.DEVELOPER, Permission.COMPONENT_READ)
+    evaluator.require_permission(Role.USER, Permission.TOOL_EXECUTE)
+
+
+def test_require_permission_raises_authorization_error(evaluator: RBACEvaluator):
+    """Test require_permission raises AuthorizationError on failure."""
+    with pytest.raises(AuthorizationError) as exc_info:
+        evaluator.require_permission(Role.GUEST, Permission.TOOL_EXECUTE)
+
+    assert "Insufficient permissions" in str(exc_info.value)
+    assert "tool:execute" in str(exc_info.value)
+    assert exc_info.value.status_code == 403
+
+
+def test_check_resource_access_tools_call(evaluator: RBACEvaluator):
+    """Test check_resource_access for tools/call."""
+    result = evaluator.check_resource_access(Role.DEVELOPER, "tools", "call")
+    assert result.allowed
+    assert result.role == Role.DEVELOPER
+    assert result.required_permission == Permission.TOOL_EXECUTE
+
+    result_guest = evaluator.check_resource_access(Role.GUEST, "tools", "call")
+    assert not result_guest.allowed
+    assert result_guest.role == Role.GUEST
+    assert result_guest.required_permission == Permission.TOOL_EXECUTE
+    assert "lacks tool:execute" in result_guest.reason
+
+
+def test_check_resource_access_audit_events(evaluator: RBACEvaluator):
+    """Test check_resource_access for audit/events."""
+    result = evaluator.check_resource_access(Role.DEVELOPER, "audit", "events")
+    assert result.allowed
+    assert result.required_permission == Permission.AUDIT_READ
+
+    result_user = evaluator.check_resource_access(Role.USER, "audit", "events")
+    assert not result_user.allowed
+    assert "lacks audit:read" in result_user.reason
+
+
+def test_check_resource_access_policies_write(evaluator: RBACEvaluator):
+    """Test check_resource_access for policies/write."""
+    result = evaluator.check_resource_access(Role.ADMIN, "policies", "write")
+    assert result.allowed
+    assert result.required_permission == Permission.POLICY_WRITE
+
+    result_dev = evaluator.check_resource_access(Role.DEVELOPER, "policies", "write")
+    assert not result_dev.allowed
+    assert "lacks policy:write" in result_dev.reason
+
+
+def test_check_resource_access_unmapped_resource(evaluator: RBACEvaluator):
+    """Test check_resource_access for unmapped resource allows access."""
+    result = evaluator.check_resource_access(Role.GUEST, "unknown", "action")
+    assert result.allowed
+    assert result.required_permission is None
+    assert "No permission mapping" in result.reason
+
+
+def test_disabled_evaluator_allows_everything(disabled_evaluator: RBACEvaluator):
+    """Test that disabled evaluator allows all permissions."""
+    assert disabled_evaluator.check_permission(Role.GUEST, Permission.SYSTEM_ADMIN)
+    assert disabled_evaluator.check_permission(Role.USER, Permission.USER_MANAGE)
+
+    result = disabled_evaluator.check_resource_access(Role.GUEST, "tools", "call")
+    assert result.allowed
+
+    disabled_evaluator.require_permission(Role.GUEST, Permission.SYSTEM_ADMIN)
+
+
+def test_require_resource_access_success(evaluator: RBACEvaluator):
+    """Test require_resource_access does not raise when access granted."""
+    evaluator.require_resource_access(Role.ADMIN, "policies", "write")
+    evaluator.require_resource_access(Role.DEVELOPER, "tools", "call")
+
+
+def test_require_resource_access_raises_authorization_error(evaluator: RBACEvaluator):
+    """Test require_resource_access raises AuthorizationError on failure."""
+    with pytest.raises(AuthorizationError) as exc_info:
+        evaluator.require_resource_access(Role.GUEST, "tools", "call")
+
+    assert "lacks tool:execute" in str(exc_info.value)
+    assert exc_info.value.status_code == 403
+
+
+def test_authz_result_structure():
+    """Test AuthzResult dataclass structure."""
+    result = AuthzResult(
+        allowed=True,
+        role=Role.DEVELOPER,
+        required_permission=Permission.COMPONENT_READ,
+        reason="Success",
+    )
+
+    assert result.allowed is True
+    assert result.role == Role.DEVELOPER
+    assert result.required_permission == Permission.COMPONENT_READ
+    assert result.reason == "Success"
+
+
+def test_all_roles_against_all_permissions(evaluator: RBACEvaluator):
+    """Comprehensive test of all roles against all permissions."""
+    test_cases = [
+        (Role.ADMIN, Permission.COMPONENT_READ, True),
+        (Role.ADMIN, Permission.COMPONENT_CREATE, True),
+        (Role.ADMIN, Permission.COMPONENT_UPDATE, True),
+        (Role.ADMIN, Permission.COMPONENT_DELETE, True),
+        (Role.ADMIN, Permission.TEMPLATE_READ, True),
+        (Role.ADMIN, Permission.TEMPLATE_CREATE, True),
+        (Role.ADMIN, Permission.TEMPLATE_UPDATE, True),
+        (Role.ADMIN, Permission.TEMPLATE_DELETE, True),
+        (Role.ADMIN, Permission.SYSTEM_READ, True),
+        (Role.ADMIN, Permission.SYSTEM_ADMIN, True),
+        (Role.ADMIN, Permission.USER_MANAGE, True),
+        (Role.ADMIN, Permission.AUDIT_READ, True),
+        (Role.ADMIN, Permission.POLICY_READ, True),
+        (Role.ADMIN, Permission.POLICY_WRITE, True),
+        (Role.ADMIN, Permission.SCORECARD_READ, True),
+        (Role.ADMIN, Permission.TOOL_EXECUTE, True),
+        (Role.DEVELOPER, Permission.COMPONENT_DELETE, False),
+        (Role.DEVELOPER, Permission.TEMPLATE_DELETE, False),
+        (Role.DEVELOPER, Permission.SYSTEM_ADMIN, False),
+        (Role.DEVELOPER, Permission.USER_MANAGE, False),
+        (Role.DEVELOPER, Permission.POLICY_WRITE, False),
+        (Role.USER, Permission.COMPONENT_DELETE, False),
+        (Role.USER, Permission.TEMPLATE_CREATE, False),
+        (Role.USER, Permission.SYSTEM_READ, False),
+        (Role.USER, Permission.AUDIT_READ, False),
+        (Role.USER, Permission.POLICY_READ, False),
+        (Role.GUEST, Permission.COMPONENT_CREATE, False),
+        (Role.GUEST, Permission.TOOL_EXECUTE, False),
+        (Role.GUEST, Permission.SYSTEM_ADMIN, False),
+    ]
+
+    for role, permission, expected in test_cases:
+        result = evaluator.check_permission(role, permission)
+        assert result == expected, f"Expected {role.value} to {'have' if expected else 'not have'} {permission.value}"
+
+
+def test_check_resource_access_without_action(evaluator: RBACEvaluator):
+    """Test check_resource_access with only resource (no action)."""
+    result = evaluator.check_resource_access(Role.DEVELOPER, "tools/call")
+    assert result.allowed
+    assert result.required_permission == Permission.TOOL_EXECUTE
+
+
+def test_default_config_enables_evaluator():
+    """Test that evaluator is enabled by default."""
+    evaluator = RBACEvaluator()
+    assert evaluator.enabled
+
+    evaluator_none_config = RBACEvaluator(config=None)
+    assert evaluator_none_config.enabled
+
+
+def test_case_insensitive_role_resolution(evaluator: RBACEvaluator):
+    """Test that role resolution is case insensitive."""
+    assert evaluator.resolve_role("ADMIN") == Role.ADMIN
+    assert evaluator.resolve_role("Admin") == Role.ADMIN
+    assert evaluator.resolve_role("DeVeLoPeR") == Role.DEVELOPER
+    assert evaluator.resolve_role("USER") == Role.USER
+    assert evaluator.resolve_role("Guest") == Role.GUEST


### PR DESCRIPTION
## Summary
- `JoseJWTValidator` with JWKS caching for Supabase-issued JWT validation
- `RBACEvaluator` with 4 roles (admin/developer/viewer/user), wildcard permissions
- Audit events API (`/api/audit/events`) for governance trail
- Security config updated: auth required, JWT-only methods, RBAC enabled by default
- Modern Horn branding in CHANGELOG

## Test plan
- [x] 36 new tests passing (test_auth.py + test_authorization.py)
- [x] ruff lint + format clean
- [ ] CI pipeline (lint, test, build, security)