### PR TITLE
feat: Add mypy type checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,27 @@ jobs:
       - name: Build package
         run: python -m build
 
+  typecheck:
+    name: Type Check (mypy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run mypy
+        run: mypy tool_router/ --config-file pyproject.toml || true
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,10 @@ lint: ## Run all linters (replaces lint-python, lint-typescript, shellcheck, lin
 	if [ -f start.sh ]; then SCRIPTS="start.sh $$SCRIPTS"; fi; \
 	if [ -n "$$SCRIPTS" ]; then shellcheck $$SCRIPTS || echo "⚠️ Shell lint issues found"; fi
 
+typecheck: ## Run mypy type checking (non-blocking)
+	@echo "🔍 Running mypy type check..."
+	mypy tool_router/ --config-file pyproject.toml || true
+
 lint-strict: ## Run all linters without fallbacks (CI-friendly)
 	@echo "🔍 Running strict linters (no fallbacks)..."
 	@echo "==> Python..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest-timeout>=2.2.0",
     "pytest-xdist>=3.0.0",
     "ruff>=0.1.0",
+    "mypy>=1.10.0",
     "pre-commit>=3.0.0",
     "psutil>=5.9.0",
     "pytest-benchmark>=4.0.0",
@@ -386,3 +387,16 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+check_untyped_defs = true
+ignore_missing_imports = true
+exclude = [
+    "tests/",
+    "performance/",
+    "apps/",
+]


### PR DESCRIPTION
## Summary
- Add mypy to dev dependencies in pyproject.toml
- Configure mypy for gradual typing
- Add non-blocking Type Check job to CI pipeline
- Add `make typecheck` target

## Test plan
- [ ] CI passes (mypy step allowed to fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)