### PR TITLE
chore: Add catalog-info.yaml for IDP service catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Service
+metadata:
+  name: mcp-gateway
+  description: Central MCP aggregation hub — routing, auth, quality gates, OpenAPI
+  tags:
+    - python
+    - mcp
+    - gateway
+    - docker
+spec:
+  owner: forge-space
+  system: siza
+  lifecycle: production
+  dependsOn:
+    - forge-patterns


### PR DESCRIPTION
## Summary
- Add Backstage-compatible catalog-info.yaml to enable IDP service catalog discovery
- Defines mcp-gateway as a Service component with metadata and dependencies
- Part of dogfooding our own IDP infrastructure across all 9 Forge Space repos

## Test plan
- [x] File created with valid YAML syntax
- [ ] Verify catalog-info.yaml appears in service catalog after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)