### PR TITLE
feat: Add Scalar interactive API documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pre-commit>=3.0.0",
     "psutil>=5.9.0",
     "pytest-benchmark>=4.0.0",
+    "scalar-fastapi>=0.0.1",
 ]
 
 [tool.pytest.ini_options]

--- a/tool_router/http_server.py
+++ b/tool_router/http_server.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
+from scalar_fastapi import get_scalar_api_reference
 
 from tool_router.api.audit import router as audit_router
 from tool_router.api.health import router as health_router
@@ -63,6 +64,8 @@ class ServiceInfoResponse(BaseModel):
     service: str = Field(description="Service name")
     version: str = Field(description="Semantic version")
     docs: str = Field(description="Path to Swagger UI")
+    redoc: str = Field(description="Path to ReDoc UI")
+    scalar: str = Field(description="Path to Scalar API reference")
     openapi: str = Field(description="Path to OpenAPI JSON spec")
 
 
@@ -89,6 +92,14 @@ class AliveResponse(BaseModel):
     timestamp: str = Field(description="ISO 8601 timestamp")
 
 
+@app.get("/api-docs", include_in_schema=False)
+async def scalar_docs():
+    return get_scalar_api_reference(
+        openapi_url=app.openapi_url,
+        title=app.title,
+    )
+
+
 @app.get(
     "/",
     tags=["health"],
@@ -101,6 +112,8 @@ async def root():
         "service": "Forge Space MCP Gateway",
         "version": "1.8.1",
         "docs": "/docs",
+        "redoc": "/redoc",
+        "scalar": "/api-docs",
         "openapi": "/openapi.json",
     }
 


### PR DESCRIPTION
## Summary

- Added `scalar-fastapi` to dev dependencies
- Integrated Scalar API reference at `/api-docs` endpoint
- Updated root endpoint to include all three documentation UIs (Swagger, ReDoc, Scalar)
- Updated `ServiceInfoResponse` model to include new docs paths

## Why Scalar?

Scalar provides a modern, interactive API documentation experience that's superior to Swagger UI and ReDoc:
- Better UX with interactive request/response examples
- Modern design and improved readability
- Faster navigation through large API specs

## Test plan

- [x] Added `scalar-fastapi>=0.0.1` to `[project.optional-dependencies].dev`
- [x] Imported `get_scalar_api_reference` from `scalar_fastapi`
- [x] Created `/api-docs` endpoint returning Scalar API reference
- [x] Updated root endpoint to return all docs paths
- [x] Ran `ruff check` and `ruff format` - all checks passed
- [x] Ran HTTP-related tests - all passing

## Endpoints

After merge:
- `/docs` - Swagger UI (unchanged)
- `/redoc` - ReDoc UI (unchanged)
- `/api-docs` - Scalar API reference (NEW)
- `/` - Service info now includes all three docs paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)