### PR TITLE
ci: Use org composite action for Python setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
+      - uses: Forge-Space/.github/.github/actions/setup-python@main
 
       - name: Ruff check
         run: ruff check tool_router/ dribbble_mcp/ --output-format=github
@@ -41,14 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
+      - uses: Forge-Space/.github/.github/actions/setup-python@main
 
       - name: Run tests
         run: |
@@ -65,12 +51,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
+      - uses: Forge-Space/.github/.github/actions/setup-python@main
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install build deps
-        run: pip install build
+          install-command: "pip install build"
 
       - name: Build package
         run: python -m build
@@ -83,14 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
+      - uses: Forge-Space/.github/.github/actions/setup-python@main
 
       - name: Run mypy
         run: mypy tool_router/ --config-file pyproject.toml || true
@@ -103,14 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
+      - uses: Forge-Space/.github/.github/actions/setup-python@main
 
       - name: pip audit
         run: pip install pip-audit && pip-audit || true


### PR DESCRIPTION
## Summary
- Replaced repeated checkout + setup-python + pip install boilerplate in all 5 CI jobs
- Uses `Forge-Space/.github/.github/actions/setup-python@main` composite action
- Build job uses custom `install-command` for build-only deps
- Reduces YAML duplication by ~30 lines

## Test plan
- [x] All 5 CI jobs (Lint, Test, Build, Type Check, Security Scan) trigger on push
- [x] Verify jobs complete successfully with composite action setup
- [x] Build job installs only `build` package (not dev deps)
- [x] All other jobs install full dev dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)