### PR TITLE
chore: Update Serena memories and gitignore egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ Makefile.original
 test-results/
 .windsurf/plans/
 .claude/plans/
+src/forge_mcp_gateway.egg-info/

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -67,3 +67,7 @@ mcp-gateway/
 - Current state: 0 open PRs, CI green, main branch clean, ruff 0 errors ecosystem-wide
 - Remaining excluded: performance/ only (via --ignore). Zero conftest exclusions.
 - Known: repository-dispatch needs PAT, GitGuardian API key expired (non-blocking)
+- v1.8.1+ (2026-03-07): PR #103 webapp routing, #129 OpenAPI enrichment, #132 rate limit headers, #133 ARCHITECTURE.md — all MERGED
+- Issue templates added (PR #131 MERGED). 3 good-first-issues created (#134-#136)
+- Tooling analysis: P0 gaps identified — security scans non-blocking, FastAPI/uvicorn not pinned, Dockerfile uses Python 3.14 (should be 3.12)
+- Recommended additions: OpenTelemetry (P1), Semgrep+Trivy (P1), prometheus-client (P2)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -121,3 +121,7 @@ symbol_info_budget:
 # Note: the backend is fixed at startup. If a project with a different backend
 # is activated post-init, an error will be returned.
 language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []


### PR DESCRIPTION
## Summary
- Update Serena project memories with v1.8.1+ state
- Add `read_only_memory_patterns` to Serena config
- Gitignore `src/forge_mcp_gateway.egg-info/` build artifact