### PR TITLE
chore(release): v1.32.2 — dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the MCP Gateway project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.32.2] - 2026-04-07
+
+### Changed
+
+- **Dependency bumps** (no functional changes):
+  - **TypeScript/Node**: `@modelcontextprotocol/sdk` 1.27.1 → 1.29.0, `hono` 4.12.8 → 4.12.10, `@types/node` 25.5.0 → 25.5.2, `@typescript-eslint/*` 8.57.1 → 8.58.0, `eslint` 10.1.0 → 10.2.0, `npm-check-updates` 19.6.5 → 20.0.0 (#294, #296).
+  - **Python**: `fastapi` 0.135.2 → 0.135.3, `uvicorn` minor bump (#297).
+  - **GitHub Actions**: `actions/cache` 5.0.3 → 5.0.4 (#290), `codecov/codecov-action` 5.5.3 → 6.0.0 (#293), `trufflesecurity/trufflehog` 3.94.0 → 3.94.2 (#291), `GitGuardian/gg-shield-action` 1.48.0 → 1.49.0 (#292).
+
 ## [1.32.1] - 2026-04-04
 
 - Internal: refresh release checks context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "forge-mcp-gateway"
-version = "1.32.1"
+version = "1.32.2"
 description = "Self-hosted MCP gateway (Context Forge) with tool-router"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Patch release wrapping the 7 dependency bumps that landed on `main` since v1.32.1. No functional changes — CHANGELOG and version bump only. CI on `main` is green for all 7 merged commits.

## Bumps included

**TypeScript/Node**
- `@modelcontextprotocol/sdk` 1.27.1 → 1.29.0
- `hono` 4.12.8 → 4.12.10
- `@types/node` 25.5.0 → 25.5.2
- `@typescript-eslint/*` 8.57.1 → 8.58.0
- `eslint` 10.1.0 → 10.2.0
- `npm-check-updates` 19.6.5 → 20.0.0 (devDep, major)

**Python**
- `fastapi` 0.135.2 → 0.135.3
- `uvicorn` minor

**GitHub Actions**
- `actions/cache` 5.0.3 → 5.0.4
- `codecov/codecov-action` 5.5.3 → 6.0.0 (major; CI verified compat on main)
- `trufflesecurity/trufflehog` 3.94.0 → 3.94.2
- `GitGuardian/gg-shield-action` 1.48.0 → 1.49.0

Source PRs: #290, #291, #292, #293, #294, #296, #297.

## Verification
- `[Unreleased]` was empty before this PR; the 7 dep PRs were merged without CHANGELOG entries.
- Diff is exactly 2 files: `CHANGELOG.md` (+9 lines) and `pyproject.toml` (1.32.1 → 1.32.2).
- After merge, `release-automation.yml` should auto-tag and trigger PyPI publish via the existing Forge Space release pipeline.