### PR TITLE
docs(specs): bootstrap spec and roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap - mcp-gateway
+
+_Auto-regenerated 2026-04-15 from `docs/specs/`._
+
+## Now (active)
+
+_(none)_
+
+## Next (proposed)
+
+- **2026-04-15-gateway-roadmap-specs**  _(proposed)_  `roadmap,specs,gateway`
+
+## Recently shipped
+
+_(none)_

--- a/docs/specs/2026-04-15-gateway-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-gateway-roadmap-specs/spec.md
@@ -1,0 +1,21 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: roadmap,specs,gateway
+---
+
+# gateway-roadmap-specs
+
+## Goal
+Represent MCP Gateway phases with durable specs that survive handoffs and support RAG retrieval.
+
+## Context
+Gateway work already uses phase language in docs and commits. Committed specs give those phases tasks, status, and PR links.
+
+## Approach
+Seed a proposed spec, regenerate docs/roadmap.md, and use spec status as the source of truth for future phase planning.
+
+## Verification
+docs/roadmap.md is generated from this spec and RAG can return it for gateway roadmap queries.

--- a/docs/specs/2026-04-15-gateway-roadmap-specs/tasks.md
+++ b/docs/specs/2026-04-15-gateway-roadmap-specs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks - gateway-roadmap-specs
+
+- [ ] Review current roadmap/backlog signals for the repo
+- [ ] Convert the next non-trivial feature into a focused spec
+- [ ] Keep docs/roadmap.md generated from specs, not hand-edited
+- [ ] Verify RAG returns this spec via source_type=spec or roadmap
+- [ ] Link the implementation PR before marking shipped


### PR DESCRIPTION
## Summary
- seed Agent-OS-style feature spec placeholder
- generate docs/roadmap.md from spec frontmatter
- make the repo visible to the shared RAG spec/roadmap workflow

## Verification
- docs-only change; inspected generated roadmap and spec layout
